### PR TITLE
Add resume column to User entity as a boolean type 

### DIFF
--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -72,7 +72,7 @@ Table users {
   uuid uuid [not null, unique, note: 'corresponds with supabase user UUID']
   email varchar(255) [not null, unique]
   is_admin boolean [not null, default: false]
-  resume_file boolean [not null, default: false]
+  resume_file_submitted boolean [not null, default: false]
 }
 
 // Stores platform-wide player related information (username,

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -72,6 +72,7 @@ Table users {
   uuid uuid [not null, unique, note: 'corresponds with supabase user UUID']
   email varchar(255) [not null, unique]
   is_admin boolean [not null, default: false]
+  resume_file boolean [not null, default: false]
 }
 
 // Stores platform-wide player related information (username,

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -72,7 +72,7 @@ Table users {
   uuid uuid [not null, unique, note: 'corresponds with supabase user UUID']
   email varchar(255) [not null, unique]
   is_admin boolean [not null, default: false]
-  resume_file_submitted boolean [not null, default: false]
+  resume_id bigint [unique, ref: - file_records.id]
 }
 
 // Stores platform-wide player related information (username,

--- a/src/main/java/org/bytefight/webserver/auth/domain/User.java
+++ b/src/main/java/org/bytefight/webserver/auth/domain/User.java
@@ -25,8 +25,8 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "is_admin", nullable = false)
     private boolean isAdmin = false;
 
-    @Column(name = "resume_file", nullable = false)
-    private boolean resume_file = false;
+    @Column(name = "resume_file_submitted", nullable = false)
+    private boolean resume_file_submitted = false;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/org/bytefight/webserver/auth/domain/User.java
+++ b/src/main/java/org/bytefight/webserver/auth/domain/User.java
@@ -25,6 +25,9 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "is_admin", nullable = false)
     private boolean isAdmin = false;
 
+    @Column(name = "resume_file", nullable = false)
+    private boolean resume_file = false;
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of();
@@ -39,4 +42,5 @@ public class User extends BaseEntity implements UserDetails {
     public String getPassword() {
         return "";
     }
+
 }

--- a/src/main/java/org/bytefight/webserver/auth/domain/User.java
+++ b/src/main/java/org/bytefight/webserver/auth/domain/User.java
@@ -4,6 +4,7 @@ import org.bytefight.webserver.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.bytefight.webserver.storage.domain.FileRecord;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -25,8 +26,9 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "is_admin", nullable = false)
     private boolean isAdmin = false;
 
-    @Column(name = "resume_file_submitted", nullable = false)
-    private boolean resume_file_submitted = false;
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = true, unique = true)
+    private FileRecord resume;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {


### PR DESCRIPTION
I added the resume column to User entity as a boolean type to see if the user submitted a resume or not. When referencing the resume, I think we can rename the submitted file into resume_[uuid].pdf 