### PR TITLE
adds multiple filters

### DIFF
--- a/src/main/java/org/bytefight/webserver/gamematch/application/GameMatchService.java
+++ b/src/main/java/org/bytefight/webserver/gamematch/application/GameMatchService.java
@@ -133,7 +133,14 @@ public class GameMatchService {
   }
 
   public Page<GameMatch> getPaginatedMatches(
-      Competition competition, String ladderSlug, String teamUuid, PageRequest page) {
+      Competition competition,
+      String ladderSlug,
+      String teamUuid,
+      String initiatingTeamUuid,
+      String submissionUuid,
+      MatchReason matchReason,
+      MatchStatus matchStatus,
+      PageRequest page) {
     Specification<GameMatch> spec =
         (root, query, cb) -> {
           List<Predicate> predicates = new ArrayList<>();
@@ -146,11 +153,33 @@ public class GameMatchService {
             predicates.add(cb.equal(root.get("ladder"), ladderSlug));
           }
 
+          if (matchReason != null) {
+            predicates.add(cb.equal(root.get("reason"), matchReason));
+          }
+
+          if (matchStatus != null) {
+            predicates.add(cb.equal(root.get("status"), matchStatus));
+          }
+
           if (teamUuid != null) {
+            UUID teamId = UUID.fromString(teamUuid);
             predicates.add(
                 cb.or(
-                    cb.equal(root.get("teamA").get("uuid"), UUID.fromString(teamUuid)),
-                    cb.equal(root.get("teamB").get("uuid"), UUID.fromString(teamUuid))));
+                    cb.equal(root.get("teamA").get("uuid"), teamId),
+                    cb.equal(root.get("teamB").get("uuid"), teamId)));
+          }
+
+          if (initiatingTeamUuid != null) {
+            predicates.add(
+                cb.equal(root.get("initiatingTeam").get("uuid"), UUID.fromString(initiatingTeamUuid)));
+          }
+
+          if (submissionUuid != null) {
+            UUID submissionId = UUID.fromString(submissionUuid);
+            predicates.add(
+                cb.or(
+                    cb.equal(root.get("submissionA").get("uuid"), submissionId),
+                    cb.equal(root.get("submissionB").get("uuid"), submissionId)));
           }
 
           return predicates.isEmpty()

--- a/src/main/java/org/bytefight/webserver/gamematch/infra/PublicGameMatchController.java
+++ b/src/main/java/org/bytefight/webserver/gamematch/infra/PublicGameMatchController.java
@@ -7,6 +7,8 @@ import org.bytefight.webserver.competition.application.CompetitionService;
 import org.bytefight.webserver.competition.domain.Competition;
 import org.bytefight.webserver.gamematch.application.GameMatchService;
 import org.bytefight.webserver.gamematch.domain.GameMatch;
+import org.bytefight.webserver.gamematch.domain.MatchReason;
+import org.bytefight.webserver.gamematch.domain.MatchStatus;
 import org.bytefight.webserver.gamematch.domain.dto.GameMatchDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -36,7 +38,11 @@ public class PublicGameMatchController {
   public ResponseEntity<Page<GameMatchDto>> searchGameMatches(
       @RequestParam String competitionSlug,
       @RequestParam(required = false) String teamUuid,
+      @RequestParam(required = false) String initiatingTeamUuid,
+      @RequestParam(required = false) String submissionUuid,
       @RequestParam(required = false) String ladder,
+      @RequestParam(required = false) MatchReason matchReason,
+      @RequestParam(required = false) MatchStatus matchStatus,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "10") int size) {
     PageRequest pageRequest =
@@ -46,7 +52,15 @@ public class PublicGameMatchController {
             .getCompetitionBySlug(competitionSlug)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     Page<GameMatch> gameMatches =
-        gameMatchService.getPaginatedMatches(competition, ladder, teamUuid, pageRequest);
+        gameMatchService.getPaginatedMatches(
+            competition,
+            ladder,
+            teamUuid,
+            initiatingTeamUuid,
+            submissionUuid,
+            matchReason,
+            matchStatus,
+            pageRequest);
 
     return ResponseEntity.ok(gameMatches.map(GameMatchDto::fromEntity));
   }


### PR DESCRIPTION
I have made a webserver branch called filters_for_team to do exactly that, handle filters in the backend. It already handles stuff like competition and team so I just added optional matchReason, matchStatus, initiatingTeamUuid, submissionUuid
Whether we will use the other filters in the frontend is a future thing but it would be helpful
Match history is basically the most important thing for players so we need to give the most possible filters
