### PR TITLE
Add player avatar upload endpoint

### DIFF
--- a/src/main/java/org/bytefight/webserver/player/application/PlayerService.java
+++ b/src/main/java/org/bytefight/webserver/player/application/PlayerService.java
@@ -3,23 +3,37 @@ package org.bytefight.webserver.player.application;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import org.bytefight.webserver.auth.domain.UsernameAlreadyExistsException;
+import org.bytefight.webserver.player.domain.AvatarDto;
 import org.bytefight.webserver.player.domain.Player;
 import org.bytefight.webserver.player.infra.PlayerRepository;
+import org.bytefight.webserver.storage.application.LocalStorageService;
+import org.bytefight.webserver.storage.domain.DownloadLinkDto;
+import org.bytefight.webserver.storage.domain.FileRecord;
 import org.bytefight.webserver.team.infra.TeamRepository;
 import org.bytefight.webserver.user.domain.User;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class PlayerService {
 
+  private static final long MAX_AVATAR_BYTES = 5_242_880L; // 5 MiB
+  private static final Set<String> ALLOWED_AVATAR_EXTENSIONS =
+      Set.of(".png", ".jpg", ".jpeg", ".webp", ".gif");
+
   private final PlayerRepository playerRepository;
   private final TeamRepository teamRepository;
+  private final LocalStorageService storageService;
 
   public Player getPlayer(Long playerId) {
     if (playerId == null) {
@@ -83,5 +97,74 @@ public class PlayerService {
 
   public List<Player> getPlayers() {
     return playerRepository.findAll().stream().toList();
+  }
+
+  @Transactional
+  public FileRecord uploadAvatar(MultipartFile file, UUID authId) throws IOException {
+    Player player = playerRepository.findByUserUuid(authId).orElseThrow();
+    FileRecord oldAvatar = player.getAvatar();
+
+    if (file == null || file.isEmpty()) {
+      throw new IOException("No avatar is uploaded");
+    }
+
+    String fileName = file.getOriginalFilename();
+
+    if (fileName == null) {
+      throw new IOException("File name is null");
+    }
+
+    String lower = fileName.toLowerCase();
+    boolean valid = ALLOWED_AVATAR_EXTENSIONS.stream().anyMatch(lower::endsWith);
+
+    if (!valid) {
+      throw new IllegalArgumentException(
+          "Please submit your avatar in PNG, JPG, JPEG, WEBP, or GIF format");
+    }
+
+    FileRecord newAvatar =
+        storageService.store(
+            file,
+            "avatars/" + player.getUser().getUuid(),
+            fileName,
+            false,
+            MAX_AVATAR_BYTES);
+
+    if (oldAvatar != null) {
+      storageService.delete(oldAvatar.getUuid().toString());
+    }
+
+    player.setAvatar(newAvatar);
+    playerRepository.save(player);
+
+    return newAvatar;
+  }
+
+  @Transactional
+  public void deleteAvatar(UUID authId) {
+    Player player = playerRepository.findByUserUuid(authId).orElseThrow();
+    FileRecord avatar = player.getAvatar();
+
+    if (avatar == null) {
+      throw new NoSuchElementException("No avatar found");
+    }
+
+    player.setAvatar(null);
+    playerRepository.save(player);
+    storageService.delete(avatar.getUuid().toString());
+  }
+
+  @Transactional
+  public AvatarDto getAvatar(UUID authId) {
+    Player player = playerRepository.findByUserUuid(authId).orElseThrow();
+    FileRecord avatar = player.getAvatar();
+
+    if (avatar == null) {
+      throw new NoSuchElementException("No avatar found");
+    }
+
+    DownloadLinkDto link =
+        storageService.getDownloadLink(avatar.getUuid().toString(), Duration.ofMinutes(5));
+    return AvatarDto.from(link, player);
   }
 }

--- a/src/main/java/org/bytefight/webserver/player/domain/AvatarDto.java
+++ b/src/main/java/org/bytefight/webserver/player/domain/AvatarDto.java
@@ -1,0 +1,23 @@
+package org.bytefight.webserver.player.domain;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Value;
+
+import org.bytefight.webserver.storage.domain.DownloadLinkDto;
+
+@Value
+@Builder
+public class AvatarDto {
+  @NotNull String uuid;
+  @NotNull String fileRecordUuid;
+  DownloadLinkDto downloadLink;
+
+  public static AvatarDto from(DownloadLinkDto downloadLink, Player player) {
+    return AvatarDto.builder()
+        .uuid(player.getUser().getUuid().toString())
+        .fileRecordUuid(player.getAvatar().getUuid().toString())
+        .downloadLink(downloadLink)
+        .build();
+  }
+}

--- a/src/main/java/org/bytefight/webserver/player/domain/Player.java
+++ b/src/main/java/org/bytefight/webserver/player/domain/Player.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import org.bytefight.webserver.common.domain.BaseEntity;
+import org.bytefight.webserver.storage.domain.FileRecord;
 import org.bytefight.webserver.user.domain.User;
 
 @Getter
@@ -25,4 +26,8 @@ public class Player extends BaseEntity {
 
   @Column(name = "username_normalized", nullable = false, unique = true, length = 50)
   private String usernameNormalized;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "avatar_file", unique = true)
+  private FileRecord avatar;
 }

--- a/src/main/java/org/bytefight/webserver/player/infra/PrivatePlayerController.java
+++ b/src/main/java/org/bytefight/webserver/player/infra/PrivatePlayerController.java
@@ -5,21 +5,30 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
 import org.bytefight.webserver.player.application.PlayerService;
+import org.bytefight.webserver.player.domain.AvatarDto;
 import org.bytefight.webserver.player.domain.Player;
 import org.bytefight.webserver.player.domain.SelfPlayerDto;
 import org.bytefight.webserver.player.domain.UpdatePlayerProfileDto;
 import org.bytefight.webserver.team.application.TeamService;
 import org.bytefight.webserver.user.domain.User;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 @Tag(name = "Player (Private)")
@@ -56,5 +65,44 @@ public class PrivatePlayerController {
     }
 
     return ResponseEntity.ok(SelfPlayerDto.from(player));
+  }
+
+  @PostMapping(value = "/avatar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @Operation(
+      operationId = "uploadAvatar",
+      summary = "Upload or replace the authenticated player's avatar (Max 5 MiB limit)")
+  public ResponseEntity<Void> uploadAvatar(
+      @AuthenticationPrincipal User user, @RequestPart("file") MultipartFile file) {
+    try {
+      playerService.uploadAvatar(file, user.getUuid());
+      return ResponseEntity.ok().build();
+    } catch (IOException | IllegalArgumentException e) {
+      // invalid type / empty file / storage failure
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Avatar upload failed. Please try again.");
+    }
+  }
+
+  @DeleteMapping(value = "/avatar")
+  @Operation(operationId = "deleteAvatar", summary = "Delete the authenticated player's avatar")
+  public ResponseEntity<Void> deleteAvatar(@AuthenticationPrincipal User user) {
+    try {
+      playerService.deleteAvatar(user.getUuid());
+      return ResponseEntity.noContent().build();
+    } catch (NoSuchElementException e) {
+      return ResponseEntity.notFound().build();
+    }
+  }
+
+  @GetMapping(value = "/avatar")
+  @Operation(
+      operationId = "getAvatar",
+      summary = "Get the authenticated player's avatar + a short-lived download link")
+  public ResponseEntity<AvatarDto> getAvatar(@AuthenticationPrincipal User user) {
+    try {
+      return ResponseEntity.ok(playerService.getAvatar(user.getUuid()));
+    } catch (NoSuchElementException e) {
+      return ResponseEntity.notFound().build();
+    }
   }
 }

--- a/src/main/resources/db/migration/V16__add_avatar_field_to_player.sql
+++ b/src/main/resources/db/migration/V16__add_avatar_field_to_player.sql
@@ -1,0 +1,15 @@
+-- Adds an optional avatar (profile picture) file reference to players.
+-- Mirrors the resume_file column added to users in V11.
+BEGIN;
+ALTER TABLE IF EXISTS public.players
+    ADD COLUMN avatar_file bigint;
+ALTER TABLE IF EXISTS public.players
+    ADD CONSTRAINT players_avatar_file_key UNIQUE (avatar_file);
+ALTER TABLE IF EXISTS public.players
+    ADD CONSTRAINT players_avatar_file_fkey FOREIGN KEY (avatar_file)
+        REFERENCES public.file_records (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        DEFERRABLE;
+
+END;


### PR DESCRIPTION
Adds profile-picture (avatar) support on the Player entity, mirroring the existing resume upload on User:
- V14 migration adds a nullable avatar_file FK on players
- Player gains an avatar FileRecord relation
- PlayerService validates image type/size (5 MiB), stores under avatars/<userUuid>, and replaces any previous avatar
- PrivatePlayerController exposes POST/DELETE/GET /api/v1/player/avatar

Files are stored on the local filesystem (storage.root); Postgres only holds the file metadata + FK.

CROSS-REPO CAVEAT: This is the BACKEND half of the profile-picture feature. The frontend half is on the `frontend` repo, branch `feature/pfp-cropper-dialog`. Pull/deploy BOTH together, or the avatar UI will 404 against a backend that lacks this endpoint.