### PR TITLE
Bound the matchmaking fan-out per event (#172)

### DIFF
--- a/src/main/java/org/bytefight/webserver/matchmaking/application/MatchmakingService.java
+++ b/src/main/java/org/bytefight/webserver/matchmaking/application/MatchmakingService.java
@@ -15,6 +15,7 @@ import org.bytefight.webserver.glicko.application.TeamStatsService;
 import org.bytefight.webserver.glicko.domain.TeamStats;
 import org.bytefight.webserver.glicko.infra.TeamStatsRepository;
 import org.bytefight.webserver.matchmaking.domain.MatchmakingEvent;
+import org.bytefight.webserver.matchmaking.infra.MatchMakingProperties;
 import org.bytefight.webserver.team.application.TeamService;
 import org.bytefight.webserver.team.domain.Team;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class MatchmakingService {
   private final GameMatchService gameMatchService;
   private final TeamStatsRepository teamStatsRepository;
   private final MatchmakingEventCreator matchmakingEventCreator;
+  private final MatchMakingProperties matchMakingProperties;
 
   @Transactional
   public MatchmakingEvent createAndScheduleEvent(Competition competition, String ladder) {
@@ -109,6 +111,20 @@ public class MatchmakingService {
     }
 
     Collections.shuffle(edges, random);
+
+    // Bound the fan-out so one tick cannot enqueue more than the fleet can clear before the next.
+    // edges is already shuffled, so truncating keeps a fair random sample across teams. Unset /
+    // non-positive cap preserves the historical full fan-out.
+    Integer cap = matchMakingProperties.getMaxMatchesPerEvent();
+    if (cap != null && cap > 0 && edges.size() > cap) {
+      log.warn(
+          "Matchmaking fan-out for ladder '{}' capped at {} matches; dropped {} this tick",
+          ladder,
+          cap,
+          edges.size() - cap);
+      edges = edges.subList(0, cap);
+    }
+
     return edges.stream()
         .map(
             (edge) -> {
@@ -146,7 +162,6 @@ public class MatchmakingService {
         m = Character.getNumericValue(partitionBaseCases.charAt(remaining));
       } else {
         m = random.nextInt(2) + 5;
-        System.out.println(m);
       }
       partitionSizes.add(m);
       remaining -= m;

--- a/src/main/java/org/bytefight/webserver/matchmaking/infra/MatchMakingProperties.java
+++ b/src/main/java/org/bytefight/webserver/matchmaking/infra/MatchMakingProperties.java
@@ -12,4 +12,12 @@ public class MatchMakingProperties {
   private boolean enabled = false;
   private String cron;
   private String tz;
+
+  /**
+   * Maximum matches a single matchmaking event may enqueue. Null or non-positive means unlimited
+   * (the historical behaviour). Set this to bound a single cron tick to something the runner fleet
+   * can clear before the next tick, otherwise the backlog is monotonic. The server can't derive
+   * fleet size itself, so this is an ops-tuned value.
+   */
+  private Integer maxMatchesPerEvent;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,11 @@ springdoc:
 gamematch:
   requeue-stale: true
   stale-threshold-minutes: 120
+matchmaking:
+  # max-matches-per-event bounds a single matchmaking tick. Unset = unlimited (historical
+  # behaviour). Set it to what the runner fleet can clear before the next tick to keep the queue
+  # from growing monotonically under automatic load.
+  max-matches-per-event:
 storage:
   max-decompressed-bytes: 524288000
 

--- a/src/test/java/org/bytefight/webserver/matchmaking/MatchmakingServiceIT.java
+++ b/src/test/java/org/bytefight/webserver/matchmaking/MatchmakingServiceIT.java
@@ -14,6 +14,7 @@ import org.bytefight.webserver.gamematch.domain.MatchStatus;
 import org.bytefight.webserver.gamematch.domain.dto.GameMatchJob;
 import org.bytefight.webserver.gamematch.infra.GameMatchRepository;
 import org.bytefight.webserver.matchmaking.application.MatchmakingService;
+import org.bytefight.webserver.matchmaking.infra.MatchMakingProperties;
 import org.bytefight.webserver.storage.domain.FileRecord;
 import org.bytefight.webserver.storage.infra.FileRecordRepository;
 import org.bytefight.webserver.submission.domain.Submission;
@@ -49,6 +50,8 @@ class MatchmakingServiceIT extends FullStackIntegrationTestBase {
   @Autowired private TopicExchange gameMatchExchange;
 
   @Autowired private org.springframework.amqp.rabbit.connection.ConnectionFactory connectionFactory;
+
+  @Autowired private MatchMakingProperties matchMakingProperties;
 
   @Test
   void createAndScheduleEventQueuesMatches() {
@@ -145,6 +148,53 @@ class MatchmakingServiceIT extends FullStackIntegrationTestBase {
               assertThat(ReflectionTestUtils.getField(match, "status"))
                   .isEqualTo(MatchStatus.waiting);
             });
+  }
+
+  @Test
+  void createAndScheduleEventRespectsMaxMatchesPerEventCap() {
+    Integer original = matchMakingProperties.getMaxMatchesPerEvent();
+    matchMakingProperties.setMaxMatchesPerEvent(5);
+    try {
+      String competitionSlug = "comp-mm-capped";
+      Competition competition =
+          testDataFactory.createCompetition(competitionSlug, "Competition", true, 2);
+      String ladder = "main";
+      testDataFactory.createLadder(competition, ladder);
+
+      for (int i = 0; i < 6; i++) {
+        createTeamWithSubmission(competition);
+      }
+
+      String routingKey = "competition." + competitionSlug + "." + ladder;
+      Queue scheduleQueue = QueueBuilder.nonDurable("test.matchmaking.queue.capped").build();
+      RabbitAdmin admin = new RabbitAdmin(connectionFactory);
+      admin.declareExchange(gameMatchExchange);
+      admin.declareQueue(scheduleQueue);
+      Binding binding = BindingBuilder.bind(scheduleQueue).to(gameMatchExchange).with(routingKey);
+      admin.declareBinding(binding);
+
+      matchmakingService.createAndScheduleEvent(competition, ladder);
+
+      int queued = 0;
+      Object message;
+      while ((message = rabbitTemplate.receiveAndConvert(scheduleQueue.getName(), 1000)) != null) {
+        assertThat(message).isInstanceOf(GameMatchJob.class);
+        queued++;
+      }
+
+      // Six teams would produce 12 matches uncapped; the cap truncates to exactly 5.
+      assertThat(queued).isEqualTo(5);
+
+      List<GameMatch> matches =
+          gameMatchRepository.findAll().stream()
+              .filter(
+                  match -> competition.equals(ReflectionTestUtils.getField(match, "competition")))
+              .filter(match -> ladder.equals(ReflectionTestUtils.getField(match, "ladder")))
+              .toList();
+      assertThat(matches).hasSize(5);
+    } finally {
+      matchMakingProperties.setMaxMatchesPerEvent(original);
+    }
   }
 
   private Team createTeamWithSubmission(Competition competition) {


### PR DESCRIPTION
Closes #172.

## Problem
`MatchmakingService.generateMatches` builds a 4-regular graph (`generate4RegularGraph`, ~2N edges) for >4 teams, so one `ScheduledMatchMaker` tick enqueues ~2N matches — ~400 at 200 teams — against a small fleet. That is a multi-hour backlog from a single cron tick, and the single biggest contributor to last semester's queue.

## Fix
Add `matchmaking.max-matches-per-event`. After the edge list is shuffled (already done for fairness), truncate it to the cap, so the matches that survive are a fair random sample across teams, and `WARN`-log how many were dropped for which ladder.

**Inert by default:** unset / non-positive = unlimited, i.e. exactly today's behaviour. Deploy is a no-op until ops sets a value tuned to what the fleet can clear per tick (the server can't derive fleet size itself). Also removed a stray `System.out.println` in `generate4RegularGraph`.

## Tests
New `MatchmakingServiceIT.createAndScheduleEventRespectsMaxMatchesPerEventCap`: with the cap at 5, six teams (which would produce 12 uncapped) enqueue exactly 5. The existing 6-teams→12 test stays as the guard that the unset default is inert.

Verified locally (no CI here): JDK-17 toolchain, Testcontainers Postgres+RabbitMQ. Independent of #173 and #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)